### PR TITLE
Fixes rm crash due to empty pipe.

### DIFF
--- a/lib/jcstress.js
+++ b/lib/jcstress.js
@@ -165,7 +165,7 @@ class JCStressRunner {
       debug(`initiating JCStress tester`);
 
       await copyTemplate(this.workPath);
-      cp.execSync(`find ${this.workPath} -name "*Test*.java" | xargs rm`);
+      cp.execSync(`find ${this.workPath} -name "*Test*.java" | xargs rm -rf`);
 
       for (let code of this.codes) {
         let pkg = code.match(/^package (.*);/m)[1];


### PR DESCRIPTION
Currently, the rm command fails since an empty set maybe piped to it. Adding the -rf parameters suppresses this failure, allowing the analyzer to proceed. This has been tested in Ubuntu. Separately, I checked that -rf also suppresses the warnings with the rm command in OS X, so it should work there too.